### PR TITLE
Specify valueFrom behavior when input is null

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -194,6 +194,9 @@ $graph:
         `InputParameter.default` field) must be applied before evaluating the
         expression.
 
+        If the value of the associated input parameter is `null`, `valueFrom` is 
+        not evaluated and nothing is added to the command line.
+
         When a binding is part of the `CommandLineTool.arguments` field,
         the `valueFrom` field is required.
 


### PR DESCRIPTION
We had the discussion about this in one of the meetings some time ago. As I recall, the decision was to not evaluate valueFrom if input is not set. I figured it would be nice to describe this behavior explicitly in the valueFrom field in the spec.
Please do modify the wording if I messed something up.