### PR TITLE
runtime.outdir and runtime.tmpdir must be distinct.

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -79,6 +79,8 @@ $graph:
         * Clarify behavior of `glob` to include directories.
         * `secondaryFiles` can now be explicitly marked as `required` or not.
         * Clarify CommandLineTool.arguments documentation
+        * Clarify that runtime.outdir and runtime.tmpdir must be distinct
+          directories.
 
       See also the [CWL Workflow Description, v1.1.0-dev1 changelog](Workflow.html#Changelog).
 
@@ -727,7 +729,8 @@ $graph:
     file paths in the input object to correspond to the Docker bind mounted
     locations. That is, the platform should rewrite values in the parameter context
     such as `runtime.outdir`, `runtime.tmpdir` and others to be valid paths
-    within the container.
+    within the container. The platform will ensure that `runtime.outdir` and
+    `runtime.tmpdir` are distinct directories.
 
     When running a tool contained in Docker, the workflow platform must not
     assume anything about the contents of the Docker container, such as the

--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -729,7 +729,7 @@ $graph:
     file paths in the input object to correspond to the Docker bind mounted
     locations. That is, the platform should rewrite values in the parameter context
     such as `runtime.outdir`, `runtime.tmpdir` and others to be valid paths
-    within the container. The platform will ensure that `runtime.outdir` and
+    within the container. The platform must ensure that `runtime.outdir` and
     `runtime.tmpdir` are distinct directories.
 
     When running a tool contained in Docker, the workflow platform must not

--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -3002,7 +3002,6 @@
           listing: []
   tags: [ required, command_line_tool ]
 
-
 - doc: Test that array of input files can be staged to directory with entryname
   label: stage_file_array
   tool: tests/stage_file_array.cwl
@@ -3106,3 +3105,14 @@
         }
       ]
   tags: [ required, command_line_tool ]
+
+- job: tests/empty.json
+  output:
+    foo:
+      class: File
+      basename: foo
+      checksum: sha1$fa98d6085770a79e44853d575cd3ab40c0f1f4de
+  tool: tests/runtime-paths-distinct.cwl
+  label: tmpdir_is_not_outdir
+  doc: Test that runtime.tmpdir is not runtime.outdir
+  tags: [ command_line_tool ]

--- a/tests/runtime-paths-distinct.cwl
+++ b/tests/runtime-paths-distinct.cwl
@@ -1,0 +1,13 @@
+class: CommandLineTool
+cwlVersion: v1.1.0-dev1
+requirements:
+  ShellCommandRequirement: {}
+inputs: {}
+outputs:
+  foo: File
+arguments:
+  - shellQuote: false
+    valueFrom: |
+      echo "cow" > "$(runtime.outdir)/foo" &&
+      echo "moo" > "$(runtime.tmpdir)/foo" &&
+      echo '{"foo": {"path": "$(runtime.outdir)/foo", "class": "File"} }' > cwl.output.json


### PR DESCRIPTION
Fixes https://github.com/common-workflow-language/common-workflow-language/issues/685