### PR TITLE
Fix typo: `$schema` to `$schemas`

### DIFF
--- a/CommandLineTool.yml
+++ b/CommandLineTool.yml
@@ -120,6 +120,7 @@ $graph:
           contain either a non-string value accepted by the field
           type, or a valid expression which returns a value having one
           of the the other types defined for that field.
+        * 2021-11-22 Errata: Fixed `$schema` typo. It is `$schemas` (plural).
 
       See also the [CWL Workflow Description, v1.1 changelog](Workflow.html#Changelog).
 

--- a/Process.yml
+++ b/Process.yml
@@ -267,8 +267,8 @@ $graph:
         `<B> owl:equivalentClass <C>` and `<B> owl:subclassOf <A>` then infer
         `<C> owl:subclassOf <A>`.
 
-        File format ontologies may be provided in the "$schema" metadata at the
-        root of the document.  If no ontologies are specified in `$schema`, the
+        File format ontologies may be provided in the "$schemas" metadata at the
+        root of the document.  If no ontologies are specified in `$schemas`, the
         runtime may perform exact file format matches.
     - name: contents
       type: string?

--- a/Workflow.yml
+++ b/Workflow.yml
@@ -106,6 +106,7 @@ $graph:
         * [WorkflowStepInput](WorkflowStepInput) now has a `loadContents` field.
         * [WorkflowStepInput.id](WorkflowStepInput) field value does not have to match an
           `input.id` value from the process specified in the `run` field.
+        * 2021-11-22 Errata: Fixed `$schema` typo. It is `$schemas` (plural).
 
       See also the [CWL Command Line Tool Description, v1.1 changelog](CommandLineTool.html#Changelog).
 

--- a/concepts.md
+++ b/concepts.md
@@ -305,7 +305,7 @@ prefix listed in the `$namespaces` section of the document as described in the
 [Schema Salad specification](SchemaSalad.html#Explicit_context).
 
 It is recommended that concepts from schema.org are used whenever possible.
-For the `$schema` field we recommend their RDF encoding: http://schema.org/version/latest/schema.rdf
+For the `$schemas` field we recommend their RDF encoding: http://schema.org/version/latest/schema.rdf
 
 Implementation extensions which modify execution semantics must be [listed in
 the `requirements` field](#Requirements_and_hints).


### PR DESCRIPTION
It is a backport of  common-workflow-language/cwl-v1.2#139.
We do not have to backport it to v1.0 because it was introduced since v1.1.