### PR TITLE
Move `label` to `id`

### DIFF
--- a/conformance_tests.yaml
+++ b/conformance_tests.yaml
@@ -5,8 +5,7 @@
       chr20.fa,
       example_human_Illumina.pe_1.fastq,
       example_human_Illumina.pe_2.fastq]
-  label: cl_basic_generation
-  id: 1
+  id: cl_basic_generation
   doc: General test of command line generation
   tags: [ required, command_line_tool ]
 
@@ -17,8 +16,7 @@
       "-YYY", example_human_Illumina.pe_2.fastq]
   job: tests/bwa-mem-job.json
   tool: tests/binding-test.cwl
-  label: nested_prefixes_arrays
-  id: 2
+  id: nested_prefixes_arrays
   doc: Test nested prefixes with arrays
   tags: [ required, command_line_tool ]
 
@@ -28,8 +26,7 @@
     '16', map2, --max-seed-hits, '-1', --max-seq-length, '20', --min-seq-length, '10']
   job: tests/tmap-job.json
   tool: tests/tmap-tool.cwl
-  label: nested_cl_bindings
-  id: 3
+  id: nested_cl_bindings
   doc: Test nested command line bindings
   tags: [ schema_def, command_line_tool ]
 
@@ -37,8 +34,7 @@
     args: [cat, hello.txt]
   job: tests/cat-job.json
   tool: tests/cat1-testcli.cwl
-  label: cl_optional_inputs_missing
-  id: 4
+  id: cl_optional_inputs_missing
   doc: Test command line with optional input (missing)
   tags: [ required, command_line_tool ]
 
@@ -46,8 +42,7 @@
     args: [cat, -n, hello.txt]
   job: tests/cat-n-job.json
   tool: tests/cat1-testcli.cwl
-  label: cl_optional_bindings_provided
-  id: 5
+  id: cl_optional_bindings_provided
   doc: Test command line with optional input (provided)
   tags: [ required, command_line_tool ]
 
@@ -60,8 +55,7 @@
     }
   job: tests/cat-job.json
   tool: tests/template-tool.cwl
-  label: initworkdir_expreng_requirements
-  id: 6
+  id: initworkdir_expreng_requirements
   doc: Test InitialWorkDirRequirement ExpressionEngineRequirement.engineConfig feature
   tags: [ initial_work_dir, inline_javascript, command_line_tool ]
 
@@ -73,8 +67,7 @@
       location: output.txt
       size: 13
   tool: tests/cat3-tool.cwl
-  label: stdout_redirect_docker
-  id: 7
+  id: stdout_redirect_docker
   doc: Test command execution in Docker with stdout redirection
   tags: [ docker, command_line_tool ]
 
@@ -86,8 +79,7 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       location: Any
       size: 13
-  label: stdout_redirect_shortcut_docker
-  id: 8
+  id: stdout_redirect_shortcut_docker
   doc: Test command execution in Docker with shortcut stdout redirection
   tags: [ docker, command_line_tool ]
 
@@ -99,15 +91,13 @@
       location: cat-out
       size: 13
   tool: tests/cat3-tool-mediumcut.cwl
-  label: stdout_redirect_mediumcut_docker
-  id: 9
+  id: stdout_redirect_mediumcut_docker
   doc: Test command execution in Docker with mediumcut stdout redirection
   tags: [ docker, command_line_tool ]
 
 - job: tests/empty.json
   tool: tests/stderr.cwl
-  label: stderr_redirect
-  id: 10
+  id: stderr_redirect
   doc: Test command line with stderr redirection
   output:
     output_file:
@@ -119,8 +109,7 @@
 
 - job: tests/empty.json
   tool: tests/stderr-shortcut.cwl
-  label: stderr_redirect_shortcut
-  id: 11
+  id: stderr_redirect_shortcut
   doc: Test command line with stderr redirection, brief syntax
   output:
     output_file:
@@ -138,8 +127,7 @@
       location: std.err
   job: tests/empty.json
   tool: tests/stderr-mediumcut.cwl
-  label: stderr_redirect_mediumcut
-  id: 12
+  id: stderr_redirect_mediumcut
   doc: Test command line with stderr redirection, named brief syntax
   tags: [ shell_command, command_line_tool ]
 
@@ -151,8 +139,7 @@
       location: output.txt
       size: 13
   tool: tests/cat4-tool.cwl
-  label: stdinout_redirect_docker
-  id: 13
+  id: stdinout_redirect_docker
   doc: Test command execution in Docker with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
@@ -160,8 +147,7 @@
   tool: tests/null-expression1-tool.cwl
   output:
     output: 1
-  label: expression_any
-  id: 14
+  id: expression_any
   doc: Test default usage of Any in expressions.
   tags: [ inline_javascript, expression_tool ]
 
@@ -169,8 +155,7 @@
   tool: tests/null-expression1-tool.cwl
   output:
     output: 1
-  label: expression_any_null
-  id: 15
+  id: expression_any_null
   doc: Test explicitly passing null to Any type inputs with default values.
   tags: [ inline_javascript, expression_tool ]
 
@@ -178,24 +163,21 @@
   tool: tests/null-expression1-tool.cwl
   output:
     output: 2
-  label: expression_any_string
-  id: 16
+  id: expression_any_string
   doc: Testing the string 'null' does not trip up an Any with a default value.
   tags: [ inline_javascript, expression_tool ]
 
 - job: tests/empty.json
   tool: tests/null-expression2-tool.cwl
   should_fail: true
-  label: expression_any_nodefaultany
-  id: 17
+  id: expression_any_nodefaultany
   doc: Test Any without defaults cannot be unspecified.
   tags: [ inline_javascript, expression_tool ]
 
 - job: tests/null-expression1-job.json
   tool: tests/null-expression2-tool.cwl
   should_fail: true
-  label: expression_any_null_nodefaultany
-  id: 18
+  id: expression_any_null_nodefaultany
   doc: Test explicitly passing null to Any type without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -203,8 +185,7 @@
   tool: tests/null-expression2-tool.cwl
   output:
     output: 2
-  label: expression_any_nullstring_nodefaultany
-  id: 19
+  id: expression_any_nullstring_nodefaultany
   doc: Testing the string 'null' does not trip up an Any without a default value.
   tags: [ inline_javascript, expression_tool ]
 
@@ -214,8 +195,7 @@
     output1: ["hello", "world"]
     output2: ["foo", "bar"]
     output3: hello
-  label: any_outputSource_compatibility
-  id: 20
+  id: any_outputSource_compatibility
   doc: Testing Any type compatibility in outputSource
   tags: [ required, workflow ]
 
@@ -227,40 +207,35 @@
       location: output
       size: 13
   tool: tests/cat-tool.cwl
-  label: stdinout_redirect
-  id: 21
+  id: stdinout_redirect
   doc: Test command execution in with stdin and stdout redirection
   tags: [ required, command_line_tool ]
 
 - job: tests/parseInt-job.json
   output: {output: 42}
   tool: tests/parseInt-tool.cwl
-  label: expression_parseint
-  id: 22
+  id: expression_parseint
   doc: Test ExpressionTool with Javascript engine
   tags: [ inline_javascript, expression_tool ]
 
 - job: tests/wc-job.json
   output: {output: 16}
   tool: tests/wc2-tool.cwl
-  label: expression_outputEval
-  id: 23
+  id: expression_outputEval
   doc: Test outputEval to transform output
   tags: [ inline_javascript, command_line_tool ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines1-wf.cwl
-  label: wf_wc_parseInt
-  id: 24
+  id: wf_wc_parseInt
   doc: Test two step workflow with imported tools
   tags: [ inline_javascript, workflow ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines2-wf.cwl
-  label: wf_wc_expressiontool
-  id: 25
+  id: wf_wc_expressiontool
   doc: Test two step workflow with inline tools
   tags: [ inline_javascript, workflow ]
 
@@ -268,8 +243,7 @@
   output:
     count_output: [16, 1]
   tool: tests/count-lines3-wf.cwl
-  label: wf_wc_scatter
-  id: 26
+  id: wf_wc_scatter
   doc: Test single step workflow with Scatter step
   tags: [ scatter, inline_javascript, workflow ]
 
@@ -277,8 +251,7 @@
   output:
     count_output: [16, 1]
   tool: tests/count-lines4-wf.cwl
-  label: wf_wc_scatter_multiple_merge
-  id: 27
+  id: wf_wc_scatter_multiple_merge
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, default merge behavior
@@ -288,8 +261,7 @@
   output:
     count_output: [32, 2]
   tool: tests/count-lines6-wf.cwl
-  label: wf_wc_scatter_multiple_nested
-  id: 28
+  id: wf_wc_scatter_multiple_nested
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, nested merge behavior
@@ -299,8 +271,7 @@
   output:
     count_output: 34
   tool: tests/count-lines7-wf.cwl
-  label: wf_wc_scatter_multiple_flattened
-  id: 29
+  id: wf_wc_scatter_multiple_flattened
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior
@@ -310,8 +281,7 @@
   output:
     count_output: 32
   tool: tests/count-lines13-wf.cwl
-  label: wf_wc_nomultiple
-  id: 30
+  id: wf_wc_nomultiple
   doc: >-
     Test that no MultipleInputFeatureRequirement is necessary when
     workflow step source is a single-item list
@@ -320,24 +290,21 @@
 - job: tests/empty.json
   output: {count_output: 1}
   tool: tests/count-lines5-wf.cwl
-  label: wf_input_default_missing
-  id: 31
+  id: wf_input_default_missing
   doc: Test workflow with default value for input parameter (missing)
   tags: [ inline_javascript, workflow ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines5-wf.cwl
-  label: wf_input_default_provided
-  id: 32
+  id: wf_input_default_provided
   doc: Test workflow with default value for input parameter (provided)
   tags: [ inline_javascript, workflow ]
 
 - job: tests/empty.json
   output: {default_output: workflow_default}
   tool: tests/echo-wf-default.cwl
-  label: wf_default_tool_default
-  id: 33
+  id: wf_default_tool_default
   doc: Test that workflow defaults override tool defaults
   tags: [ required, workflow ]
 
@@ -349,8 +316,7 @@
       location: out
       size: 15
   tool: tests/env-tool1.cwl
-  label: envvar_req
-  id: 34
+  id: envvar_req
   doc: Test EnvVarRequirement
   tags: [ env_var, command_line_tool ]
 
@@ -358,8 +324,7 @@
   output:
     out: ["foo one", "foo two", "foo three", "foo four"]
   tool: tests/scatter-wf1.cwl
-  label: wf_scatter_single_param
-  id: 35
+  id: wf_scatter_single_param
   doc: Test workflow scatter with single scatter parameter
   tags: [ scatter, workflow ]
 
@@ -367,8 +332,7 @@
   output:
     out: [["foo one three", "foo one four"], ["foo two three", "foo two four"]]
   tool: tests/scatter-wf2.cwl
-  label: wf_scatter_two_nested_crossproduct
-  id: 36
+  id: wf_scatter_two_nested_crossproduct
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -376,8 +340,7 @@
   output:
     out: ["foo one three", "foo one four", "foo two three", "foo two four"]
   tool: "tests/scatter-wf3.cwl#main"
-  label: wf_scatter_two_flat_crossproduct
-  id: 37
+  id: wf_scatter_two_flat_crossproduct
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -385,8 +348,7 @@
   output:
     out: ["foo one three", "foo two four"]
   tool: "tests/scatter-wf4.cwl#main"
-  label: wf_scatter_two_dotproduct
-  id: 38
+  id: wf_scatter_two_dotproduct
   doc: Test workflow scatter with two scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -394,8 +356,7 @@
   output:
     out: []
   tool: tests/scatter-wf1.cwl
-  label: wf_scatter_emptylist
-  id: 39
+  id: wf_scatter_emptylist
   doc: Test workflow scatter with single empty list parameter
   tags: [ scatter, workflow ]
 
@@ -403,8 +364,7 @@
   output:
     out: [[], []]
   tool: tests/scatter-wf2.cwl
-  label: wf_scatter_nested_crossproduct_secondempty
-  id: 40
+  id: wf_scatter_nested_crossproduct_secondempty
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with second list empty
   tags: [ scatter, workflow ]
 
@@ -412,8 +372,7 @@
   output:
     out: []
   tool: "tests/scatter-wf3.cwl#main"
-  label: wf_scatter_nested_crossproduct_firstempty
-  id: 41
+  id: wf_scatter_nested_crossproduct_firstempty
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method with first list empty
   tags: [ scatter, workflow ]
 
@@ -421,8 +380,7 @@
   output:
     out: []
   tool: "tests/scatter-wf3.cwl#main"
-  label: wf_scatter_flat_crossproduct_oneempty
-  id: 42
+  id: wf_scatter_flat_crossproduct_oneempty
   doc: Test workflow scatter with two scatter parameters, one of which is empty and flat_crossproduct join method
   tags: [ scatter, workflow ]
 
@@ -430,8 +388,7 @@
   output:
     out: []
   tool: "tests/scatter-wf4.cwl#main"
-  label: wf_scatter_dotproduct_twoempty
-  id: 43
+  id: wf_scatter_dotproduct_twoempty
   doc: Test workflow scatter with two empty scatter parameters and dotproduct join method
   tags: [ scatter, workflow ]
 
@@ -439,16 +396,14 @@
   job: tests/env-job.json
   output:
     {"out": "hello test env\n"}
-  label: any_input_param
-  id: 44
+  id: any_input_param
   doc: Test Any type input parameter
   tags: [ required, command_line_tool ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines8-wf.cwl
-  label: nested_workflow
-  id: 45
+  id: nested_workflow
   doc: Test nested workflow
   tags: [ subworkflow, workflow, inline_javascript ]
 
@@ -460,8 +415,7 @@
       location: out
       size: 15
   tool: tests/env-wf1.cwl
-  label: requirement_priority
-  id: 46
+  id: requirement_priority
   doc: Test requirement priority
   tags: [ env_var, workflow ]
 
@@ -473,8 +427,7 @@
       location: out
       size: 9
   tool: tests/env-wf2.cwl
-  label: requirement_override_hints
-  id: 47
+  id: requirement_override_hints
   doc: Test requirements override hints
   tags: [ env_var, workflow ]
 
@@ -486,40 +439,35 @@
       location: out
       size: 9
   tool: tests/env-wf3.cwl
-  label: requirement_workflow_steps
-  id: 48
+  id: requirement_workflow_steps
   doc: Test requirements on workflow steps
   tags: [ env_var, workflow ]
 
 - job: tests/empty.json
   output: {count_output: 16}
   tool: tests/count-lines9-wf.cwl
-  label: step_input_default_value
-  id: 49
+  id: step_input_default_value
   doc: Test default value on step input parameter
   tags: [ inline_javascript, workflow ]
 
 - job: tests/empty.json
   output: {count_output: 16}
   tool: tests/count-lines11-wf.cwl
-  label: step_input_default_value_nosource
-  id: 50
+  id: step_input_default_value_nosource
   doc: Test use default value on step input parameter with empty source
   tags: [ inline_javascript, workflow ]
 
 - job: tests/file1-null.json
   output: {count_output: 16}
   tool: tests/count-lines11-wf.cwl
-  label: step_input_default_value_nullsource
-  id: 51
+  id: step_input_default_value_nullsource
   doc: Test use default value on step input parameter with null source
   tags: [ inline_javascript, workflow ]
 
 - job: tests/cat-job.json
   output: {count_output: 1}
   tool: tests/count-lines11-wf.cwl
-  label: step_input_default_value_overriden
-  id: 52
+  id: step_input_default_value_overriden
   doc: Test default value on step input parameter overridden by provided source
   tags: [ inline_javascript, workflow ]
 
@@ -531,8 +479,7 @@
       location: output.txt
       size: 1111
   tool: tests/revsort.cwl
-  label: wf_simple
-  id: 53
+  id: wf_simple
   doc: Test simple workflow
   tags: [ required, workflow ]
 
@@ -544,8 +491,7 @@
       location: output.txt
       size: 13
   tool: tests/cat5-tool.cwl
-  label: hints_unknown_ignored
-  id: 54
+  id: hints_unknown_ignored
   doc: Test unknown hints are ignored.
   tags: [ required, command_line_tool ]
 
@@ -624,8 +570,7 @@
         "size": 1111
     }
   tool: "tests/search.cwl#main"
-  label: initial_workdir_secondary_files_expr
-  id: 55
+  id: initial_workdir_secondary_files_expr
   doc: >-
     Test InitialWorkDirRequirement linking input files and capturing secondaryFiles
     on input and output. Also tests the use of a variety of parameter references
@@ -640,8 +585,7 @@
       location: fish.txt
       size: 1111
   tool: tests/rename.cwl
-  label: rename
-  id: 56
+  id: rename
   doc: >-
     Test InitialWorkDirRequirement with expression in filename.
   tags: [ initial_work_dir, command_line_tool ]
@@ -654,8 +598,7 @@
         location: example.conf
         size: 16
   tool: tests/iwdr-entry.cwl
-  label: initial_workdir_trailingnl
-  id: 57
+  id: initial_workdir_trailingnl
   doc: Test if trailing newline is present in file entry in InitialWorkDir
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -663,8 +606,7 @@
   output:
     output: 16
   tool: tests/wc4-tool.cwl
-  label: inline_expressions
-  id: 58
+  id: inline_expressions
   doc: >-
     Test inline expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -677,8 +619,7 @@
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: tests/schemadef-tool.cwl
-  label: schemadef_req_tool_param
-  id: 59
+  id: schemadef_req_tool_param
   doc: >-
     Test SchemaDefRequirement definition used in tool parameter
   tags: [ schema_def, command_line_tool ]
@@ -691,8 +632,7 @@
         class: File
         checksum: "sha1$f12e6cfe70f3253f70b0dbde17c692e7fb0f1e5e"
   tool: tests/schemadef-wf.cwl
-  label: schemadef_req_wf_param
-  id: 60
+  id: schemadef_req_wf_param
   doc: >-
     Test SchemaDefRequirement definition used in workflow parameter
   tags: [ schema_def, workflow ]
@@ -771,8 +711,7 @@
     "t28": 3
     }
   tool: tests/params.cwl
-  label: param_evaluation_noexpr
-  id: 61
+  id: param_evaluation_noexpr
   doc: Test parameter evaluation, no support for JS expressions
   tags: [ required, command_line_tool ]
 
@@ -850,8 +789,7 @@
     "t28": 3
     }
   tool: tests/params2.cwl
-  label: param_evaluation_expr
-  id: 62
+  id: param_evaluation_expr
   doc: >-
     Test parameter evaluation, with support for JS expressions
   tags: [ inline_javascript, command_line_tool ]
@@ -859,8 +797,7 @@
 - output: {}
   job: tests/cat-job.json
   tool: tests/metadata.cwl
-  label: metadata
-  id: 63
+  id: metadata
   doc: Test metadata
   tags: [ required, command_line_tool ]
 
@@ -873,8 +810,7 @@
         "class": "File"
         "checksum": "sha1$97fe1b50b4582cebc7d853796ebd62e3e163aa3f"
   tool: tests/formattest.cwl
-  label: format_checking
-  id: 64
+  id: format_checking
   doc: >-
     Test simple format checking.
   tags: [ required, command_line_tool ]
@@ -888,8 +824,7 @@
         "class": "File"
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: tests/formattest2.cwl
-  label: format_checking_subclass
-  id: 65
+  id: format_checking_subclass
   doc: >-
     Test format checking against ontology using subclassOf.
   tags: [ required, command_line_tool ]
@@ -903,8 +838,7 @@
         "class": "File"
         "checksum": "sha1$971d88faeda85a796752ecf752b7e2e34f1337ce"
   tool: tests/formattest3.cwl
-  label: format_checking_equivalentclass
-  id: 66
+  id: format_checking_equivalentclass
   doc: >-
     Test format checking against ontology using equivalentClass.
   tags: [ required, command_line_tool ]
@@ -918,8 +852,7 @@
         size: 13
         class: "File"
         checksum: "sha1$47a013e660d408619d894b20806b1d5086aab03b"
-  label: output_secondaryfile_optional
-  id: 67
+  id: output_secondaryfile_optional
   doc: >-
     Test optional output file and optional secondaryFile on output.
   tags: [ docker, command_line_tool ]
@@ -928,8 +861,7 @@
   output:
     out: "\n"
   tool: tests/vf-concat.cwl
-  label: valuefrom_ignored_null
-  id: 68
+  id: valuefrom_ignored_null
   doc: Test that valueFrom is ignored when the parameter is null
   tags: [ inline_javascript, command_line_tool ]
 
@@ -937,32 +869,28 @@
   output:
     out: "a string\n"
   tool: tests/vf-concat.cwl
-  label: valuefrom_secondexpr_ignored
-  id: 69
+  id: valuefrom_secondexpr_ignored
   doc: Test that second expression in concatenated valueFrom is not ignored
   tags: [ inline_javascript, command_line_tool ]
 
 - job: tests/step-valuefrom-wf.json
   output: {count_output: 16}
   tool: tests/step-valuefrom-wf.cwl
-  label: valuefrom_wf_step
-  id: 70
+  id: valuefrom_wf_step
   doc: Test valueFrom on workflow step.
   tags: [ step_input, inline_javascript, workflow ]
 
 - job: tests/step-valuefrom-job.json
   output: {val: "3\n"}
   tool: tests/step-valuefrom2-wf.cwl
-  label: valuefrom_wf_step_multiple
-  id: 71
+  id: valuefrom_wf_step_multiple
   doc: Test valueFrom on workflow step with multiple sources
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
 - job: tests/step-valuefrom-job.json
   output: {val: "3\n"}
   tool: tests/step-valuefrom3-wf.cwl
-  label: valuefrom_wf_step_other
-  id: 72
+  id: valuefrom_wf_step_other
   doc: Test valueFrom on workflow step referencing other inputs
   tags: [ step_input, inline_javascript, workflow ]
 
@@ -983,8 +911,7 @@
         }
     }
   tool: tests/record-output.cwl
-  label: record_output_binding
-  id: 73
+  id: record_output_binding
   doc: Test record type output binding.
   tags: [ shell_command, command_line_tool ]
 
@@ -998,8 +925,7 @@
     }
   }
   tool: tests/test-cwl-out.cwl
-  label: docker_json_output_path
-  id: 74
+  id: docker_json_output_path
   doc: >-
     Test support for reading cwl.output.json when running in a Docker container
     and just 'path' is provided.
@@ -1015,8 +941,7 @@
     }
   }
   tool: tests/test-cwl-out2.cwl
-  label: docker_json_output_location
-  id: 75
+  id: docker_json_output_location
   doc: >-
     Test support for reading cwl.output.json when running in a Docker container
     and just 'location' is provided.
@@ -1043,8 +968,7 @@
         "checksum": "sha1$da39a3ee5e6b4b0d3255bfef95601890afd80709"
     }]
   tool: tests/glob-expr-list.cwl
-  label: multiple_glob_expr_list
-  id: 76
+  id: multiple_glob_expr_list
   doc: Test support for returning multiple glob patterns from expression
   tags: [ required, command_line_tool ]
 
@@ -1052,8 +976,7 @@
   output:
     out: ["foo one one", "foo one two", "foo one three", "foo one four"]
   tool: tests/scatter-valuefrom-wf1.cwl
-  label: wf_scatter_oneparam_valuefrom
-  id: 77
+  id: wf_scatter_oneparam_valuefrom
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (first and current el)
   tags: [ scatter, step_input, workflow ]
 
@@ -1061,8 +984,7 @@
   output:
     out: [["foo one one three", "foo one one four"], ["foo one two three", "foo one two four"]]
   tool: tests/scatter-valuefrom-wf2.cwl
-  label: wf_scatter_twoparam_nested_crossproduct_valuefrom
-  id: 78
+  id: wf_scatter_twoparam_nested_crossproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and nested_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1070,8 +992,7 @@
   output:
     out: ["foo one one three", "foo one one four", "foo one two three", "foo one two four"]
   tool: "tests/scatter-valuefrom-wf3.cwl#main"
-  label: wf_scatter_twoparam_flat_crossproduct_valuefrom
-  id: 79
+  id: wf_scatter_twoparam_flat_crossproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and flat_crossproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1079,8 +1000,7 @@
   output:
     out: ["foo one one three", "foo one two four"]
   tool: "tests/scatter-valuefrom-wf4.cwl#main"
-  label: wf_scatter_twoparam_dotproduct_valuefrom
-  id: 80
+  id: wf_scatter_twoparam_dotproduct_valuefrom
   doc: Test workflow scatter with two scatter parameters and dotproduct join method and valueFrom on step input
   tags: [ scatter, step_input, workflow ]
 
@@ -1088,15 +1008,13 @@
   output:
     out: ["foo one one", "foo two two", "foo three three", "foo four four"]
   tool: tests/scatter-valuefrom-wf5.cwl
-  label: wf_scatter_oneparam_valuefrom_twice_current_el
-  id: 81
+  id: wf_scatter_oneparam_valuefrom_twice_current_el
   doc: Test workflow scatter with single scatter parameter and two valueFrom on step input (current el twice)
   tags: [ scatter, step_input, workflow ]
 
 - job: tests/scatter-valuefrom-job3.json
   tool: tests/scatter-valuefrom-wf6.cwl
-  label: wf_scatter_oneparam_valueFrom
-  id: 82
+  id: wf_scatter_oneparam_valueFrom
   doc: Test valueFrom eval on scattered input parameter
   output:
     out_message: [
@@ -1125,8 +1043,7 @@
     }
   }
   tool: "tests/conflict-wf.cwl#collision"
-  label: wf_two_inputfiles_namecollision
-  id: 83
+  id: wf_two_inputfiles_namecollision
   doc: Test workflow two input files with same name.
   tags: [ required, workflow ]
 
@@ -1139,8 +1056,7 @@
         "class": "File"
     }
   tool: tests/dir.cwl
-  label: directory_input_param_ref
-  id: 84
+  id: directory_input_param_ref
   doc: Test directory input with parameter reference
   tags: [ shell_command, command_line_tool ]
 
@@ -1153,8 +1069,7 @@
         "class": "File"
     }
   tool: tests/dir2.cwl
-  label: directory_input_docker
-  id: 85
+  id: directory_input_docker
   doc: Test directory input in Docker
   tags: [ command_line_tool, shell_command ]
 
@@ -1178,8 +1093,7 @@
         ],
     }
   tool: tests/dir3.cwl
-  label: directory_output
-  id: 86
+  id: directory_output
   doc: Test directory output
   tags: [ required, command_line_tool ]
 
@@ -1193,8 +1107,7 @@
     }
   }
   tool: tests/dir4.cwl
-  label: directory_secondaryfiles
-  id: 87
+  id: directory_secondaryfiles
   doc: Test directories in secondaryFiles
   tags: [ shell_command, command_line_tool ]
 
@@ -1208,8 +1121,7 @@
     }
   }
   tool: tests/dir5.cwl
-  label: dynamic_initial_workdir
-  id: 88
+  id: dynamic_initial_workdir
   doc: Test dynamic initial work dir
   tags: [ shell_command, initial_work_dir, command_line_tool ]
 
@@ -1223,8 +1135,7 @@
     }
   }
   tool: tests/stagefile.cwl
-  label: writable_stagedfiles
-  id: 89
+  id: writable_stagedfiles
   doc: Test writable staged files.
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1236,8 +1147,7 @@
       location: output.txt
       size: 18
   tool: tests/cat3-tool.cwl
-  label: input_file_literal
-  id: 90
+  id: input_file_literal
   doc: Test file literal as input
   tags: [ required, command_line_tool ]
 
@@ -1249,8 +1159,7 @@
         class: File
         size: 0
   tool: tests/linkfile.cwl
-  label: initial_workdir_expr
-  id: 91
+  id: initial_workdir_expr
   doc: Test expression in InitialWorkDir listing
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1262,8 +1171,7 @@
         class: File
         size: 21
   tool: tests/nameroot.cwl
-  label: nameroot_nameext_stdout_expr
-  id: 92
+  id: nameroot_nameext_stdout_expr
   doc: Test nameroot/nameext expression in arguments, stdout
   tags: [ required, command_line_tool ]
 
@@ -1276,8 +1184,7 @@
         "class": "File"
     }
   tool: tests/dir6.cwl
-  label: input_dir_inputbinding
-  id: 93
+  id: input_dir_inputbinding
   doc: Test directory input with inputBinding
   tags: [ shell_command, command_line_tool ]
 
@@ -1289,24 +1196,21 @@
         class: File
         size: 2
   tool: tests/nested-array.cwl
-  label: cl_gen_arrayofarrays
-  id: 94
+  id: cl_gen_arrayofarrays
   doc: Test command line generation of array-of-arrays
   tags: [ required, command_line_tool ]
 
 - job: tests/empty.json
   output: {}
   tool: tests/envvar.cwl
-  label: env_home_tmpdir
-  id: 95
+  id: env_home_tmpdir
   doc: Test $HOME and $TMPDIR are set correctly
   tags: [ shell_command, command_line_tool ]
 
 - job: tests/empty.json
   output: {}
   tool: tests/envvar2.cwl
-  label: env_home_tmpdir_docker
-  id: 96
+  id: env_home_tmpdir_docker
   doc: Test $HOME and $TMPDIR are set correctly in Docker
   tags: [ shell_command, command_line_tool ]
 
@@ -1319,8 +1223,7 @@
         "size": 2
     }
   tool: "tests/js-expr-req-wf.cwl#wf"
-  label: expressionlib_tool_wf_override
-  id: 97
+  id: expressionlib_tool_wf_override
   doc: Test that expressionLib requirement of individual tool step overrides expressionLib of workflow.
   tags: [ inline_javascript, workflow ]
 
@@ -1338,16 +1241,14 @@
       "class": "File"
       "size": 12010
   tool: tests/initialworkdirrequirement-docker-out.cwl
-  label: initial_workdir_output
-  id: 98
+  id: initial_workdir_output
   doc: Test output of InitialWorkDir
   tags: [ docker, initial_work_dir, command_line_tool ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines10-wf.cwl
-  label: embedded_subworkflow
-  id: 99
+  id: embedded_subworkflow
   doc: Test embedded subworkflow
   tags: [ subworkflow, workflow ]
 
@@ -1361,16 +1262,14 @@
     }
   }
   tool: tests/docker-array-secondaryfiles.cwl
-  label: filesarray_secondaryfiles
-  id: 100
+  id: filesarray_secondaryfiles
   doc: Test required, optional and null secondaryFiles on array of files.
   tags: [ docker, inline_javascript, shell_command, command_line_tool ]
 
 - job: tests/docker-array-secondaryfiles-job2.json
   should_fail: true
   tool: tests/docker-array-secondaryfiles.cwl
-  label: filesarray_secondaryfiles2
-  id: 101
+  id: filesarray_secondaryfiles2
   doc: Test required, optional and null secondaryFiles on array of files.
   tags: [ docker, inline_javascript, shell_command, command_line_tool ]
 
@@ -1396,8 +1295,7 @@
     }
   }
   tool: tests/dir7.cwl
-  label: exprtool_directory_literal
-  id: 102
+  id: exprtool_directory_literal
   doc: Test directory literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1409,8 +1307,7 @@
       checksum: "sha1$fea23663b9c8ed71968f86415b5ec091bb111448"
       size: 19
   tool: tests/file-literal-ex.cwl
-  label: exprtool_file_literal
-  id: 103
+  id: exprtool_file_literal
   doc: Test file literal output created by ExpressionTool
   tags: [ inline_javascript, expression_tool ]
 
@@ -1423,8 +1320,7 @@
         "size": 0
     }
   tool: tests/docker-output-dir.cwl
-  label: dockeroutputdir
-  id: 104
+  id: dockeroutputdir
   doc: Test dockerOutputDirectory
   tags: [ docker, command_line_tool ]
 
@@ -1436,16 +1332,14 @@
       location: out
       size: 15
   tool: tests/imported-hint.cwl
-  label: hints_import
-  id: 105
+  id: hints_import
   doc: Test hints with $import
   tags: [ required, command_line_tool ]
 
 - output: {}
   job: tests/default_path_job.yml
   tool: tests/default_path.cwl
-  label: default_path_notfound_warning
-  id: 106
+  id: default_path_notfound_warning
   doc: Test warning instead of error when default path is not found
   tags: [ required, command_line_tool ]
 
@@ -1453,8 +1347,7 @@
     args: [-A,'2',-B,baz,-C,'10','9','8','7','6','5','4','3','2','1',-D]
   job: tests/empty.json
   tool: tests/inline-js.cwl
-  label: inlinejs_req_expressions
-  id: 107
+  id: inlinejs_req_expressions
   doc: Test InlineJavascriptRequirement with multiple expressions in the same tool
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1509,8 +1402,7 @@
         "size": 0
       }
   tool: tests/recursive-input-directory.cwl
-  label: input_dir_recurs_copy_writable
-  id: 108
+  id: input_dir_recurs_copy_writable
   doc: Test if a writable input directory is recursively copied and writable
   tags: [ initial_work_dir, shell_command, command_line_tool ]
 
@@ -1518,8 +1410,7 @@
     out: "t\n"
   job: tests/empty.json
   tool: tests/null-defined.cwl
-  label: null_missing_params
-  id: 109
+  id: null_missing_params
   doc: Test that missing parameters are null (not undefined) in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1527,8 +1418,7 @@
     out: "f\n"
   job: tests/cat-job.json
   tool: tests/null-defined.cwl
-  label: param_notnull_expr
-  id: 110
+  id: param_notnull_expr
   doc: Test that provided parameter is not null in expression
   tags: [ inline_javascript, command_line_tool ]
 
@@ -1540,8 +1430,7 @@
       location: output.txt
       size: 1111
   tool: tests/revsort-packed.cwl#main
-  label: wf_compound_doc
-  id: 111
+  id: wf_compound_doc
   doc: Test compound workflow document
   tags: [ required, workflow ]
 
@@ -1560,16 +1449,14 @@
       location: Any
       path: Any
   tool: tests/basename-fields-test.cwl
-  label: nameroot_nameext_generated
-  id: 112
+  id: nameroot_nameext_generated
   doc: Test that nameroot and nameext are generated from basename at execution time by the runner
   tags: [ step_input_expression, workflow ]
 
 - job: tests/wc-job.json
   output: {}
   tool: tests/initialwork-path.cwl
-  label: initialworkpath_output
-  id: 113
+  id: initialworkpath_output
   doc: Test that file path in $(inputs) for initialworkdir is in $(outdir).
   tags: [ initial_work_dir, command_line_tool ]
 
@@ -1577,8 +1464,7 @@
   output:
     count_output: 34
   tool: tests/count-lines12-wf.cwl
-  label: wf_scatter_twopar_oneinput_flattenedmerge
-  id: 114
+  id: wf_scatter_twopar_oneinput_flattenedmerge
   doc: >-
     Test single step workflow with Scatter step and two data links connected to
     same input, flattened merge behavior. Workflow inputs are set as list
@@ -1588,8 +1474,7 @@
   output:
     result: 12
   tool: tests/sum-wf.cwl
-  label: wf_multiplesources_multipletypes
-  id: 115
+  id: wf_multiplesources_multipletypes
   doc: Test step input with multiple sources with multiple types
   tags: [ step_input, inline_javascript, multiple_input, workflow ]
 
@@ -1609,8 +1494,7 @@
     }
   }
   tool: tests/shellchar.cwl
-  label: shelldir_notinterpreted
-  id: 116
+  id: shelldir_notinterpreted
   doc: "Test that shell directives are not interpreted."
   tags: [ required, command_line_tool ]
 
@@ -1630,8 +1514,7 @@
     }
   }
   tool: tests/shellchar2.cwl
-  label: shelldir_quoted
-  id: 117
+  id: shelldir_quoted
   doc: "Test that shell directives are quoted."
   tags: [ shell_command, command_line_tool ]
 
@@ -1652,8 +1535,7 @@
         "class": "Directory"
     }
   tool: tests/writable-dir.cwl
-  label: initial_workdir_empty_writable
-  id: 118
+  id: initial_workdir_empty_writable
   doc: Test empty writable dir with InitialWorkDirRequirement
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
@@ -1674,15 +1556,13 @@
         "class": "Directory"
     }
   tool: tests/writable-dir-docker.cwl
-  label: initial_workdir_empty_writable_docker
-  id: 119
+  id: initial_workdir_empty_writable_docker
   doc: Test empty writable dir with InitialWorkDirRequirement inside Docker
   tags: [ inline_javascript, initial_work_dir, command_line_tool ]
 
 - job: tests/dynresreq-job.yaml
   tool: tests/dynresreq.cwl
-  label: dynamic_resreq_inputs
-  id: 120
+  id: dynamic_resreq_inputs
   doc: Test dynamic resource reqs referencing inputs
   output:
      output: {
@@ -1701,15 +1581,13 @@
       location: output.txt
       size: 18
   tool: tests/cat3-nodocker.cwl
-  label: fileliteral_input_docker
-  id: 121
+  id: fileliteral_input_docker
   doc: Test file literal as input without Docker
   tags: [ required, command_line_tool ]
 
 - doc: Test that OutputBinding.glob is sorted as specified by POSIX
-  id: 122
   job: tests/empty.json
-  label: outputbinding_glob_sorted
+  id: outputbinding_glob_sorted
   tool: tests/glob_test.cwl
   output:
     letters:
@@ -1744,7 +1622,6 @@
   tags: [ required, command_line_tool ]
 
 - doc: Test InitialWorkDirRequirement with a nested directory structure from another step
-  id: 123
   job: tests/empty.json
   output:
     ya_empty:
@@ -1753,7 +1630,7 @@
       location: ya
       size: 0
   tool: tests/iwdr_with_nested_dirs.cwl
-  label: initialworkdir_nesteddir
+  id: initialworkdir_nesteddir
   tags: [ initial_work_dir, workflow ]
 
 - job: tests/bool-empty-inputbinding-job.json
@@ -1762,8 +1639,7 @@
     ]
   }
   tool: tests/bool-empty-inputbinding.cwl
-  label: booleanflags_cl_noinputbinding
-  id: 124
+  id: booleanflags_cl_noinputbinding
   doc: "Test that boolean flags do not appear on command line if inputBinding is empty and not null"
   tags: [ required, command_line_tool ]
 
@@ -1772,25 +1648,22 @@
     "args": []
   }
   tool: tests/stage-unprovided-file.cwl
-  label: expr_reference_self_noinput
-  id: 125
+  id: expr_reference_self_noinput
   doc: Test that expression engine does not fail to evaluate reference to self
        with unprovided input
   tags: [ required, command_line_tool ]
 
 - tool: tests/exit-success.cwl
-  label: success_codes
-  id: 126
+  id: success_codes
   doc: Test successCodes
   job: tests/empty.json
   output: {}
   tags: [ required, command_line_tool ]
 
 - job: tests/dynresreq-job.yaml
-  id: 127
   doc: Test simple workflow with a dynamic resource requirement
   tool: tests/dynresreq-workflow.cwl
-  label: dynamic_resreq_wf
+  id: dynamic_resreq_wf
   output:
      cores: {
         "location": "output",
@@ -1805,15 +1678,13 @@
     "args": []
   }
   tool: tests/empty-array-input.cwl
-  label: cl_empty_array_input
-  id: 128
+  id: cl_empty_array_input
   doc: "Test that empty array input does not add anything to command line"
   tags: [ required, command_line_tool ]
 
 - job: tests/empty.json
   tool: tests/steplevel-resreq.cwl
-  label: resreq_step_overrides_wf
-  id: 129
+  id: resreq_step_overrides_wf
   doc: Test that ResourceRequirement on a step level redefines requirement on the workflow level
   output:
      out: {
@@ -1829,15 +1700,13 @@
     "args": ["replacementValue"]
   }
   tool: tests/valueFrom-constant.cwl
-  label: valuefrom_constant_overrides_inputs
-  id: 130
+  id: valuefrom_constant_overrides_inputs
   doc: Test valueFrom with constant value overriding provided array inputs
   tags: [ required, command_line_tool ]
 
 - job: tests/dynresreq-dir-job.yaml
   tool: tests/dynresreq-dir.cwl
-  label: dynamic_resreq_filesizes
-  id: 131
+  id: dynamic_resreq_filesizes
   doc: Test dynamic resource reqs referencing the size of Files inside a Directory
   output:
      output: {
@@ -1850,8 +1719,7 @@
 
 - job: tests/empty.json
   tool: tests/pass-unconnected.cwl
-  label: wf_step_connect_undeclared_param
-  id: 132
+  id: wf_step_connect_undeclared_param
   doc: >-
     Test that it is not an error to connect a parameter to a workflow
     step, even if the parameter doesn't appear in the `run` process
@@ -1861,8 +1729,7 @@
 
 - job: tests/empty.json
   tool: tests/fail-unconnected.cwl
-  label: wf_step_access_undeclared_param
-  id: 133
+  id: wf_step_access_undeclared_param
   doc: >-
     Test that parameters that don't appear in the `run` process
     inputs are not present in the input object used to run the tool.
@@ -1877,8 +1744,7 @@
        checksum: "sha1$7d5ca8c0c03e883c56c4eb1ef6f6bb9bccad4d86"
        size: 8
   tool: tests/envvar3.cwl
-  label: env_home_tmpdir_docker_no_return_code
-  id: 134
+  id: env_home_tmpdir_docker_no_return_code
   doc: Test $HOME and $TMPDIR are set correctly in Docker without using return code
   tags: [ shell_command, command_line_tool ]
 
@@ -1886,8 +1752,7 @@
   output:
     out: ["foo one one", "foo one two", "foo one three", "foo one four"]
   tool: tests/scatter-valuefrom-inputs-wf1.cwl
-  label: wf_scatter_oneparam_valuefrom_inputs
-  id: 135
+  id: wf_scatter_oneparam_valuefrom_inputs
   doc: Test workflow scatter with single scatter parameter and two valueFrom using $inputs (first and current el)
   tags: [ scatter, step_input, workflow ]
 
@@ -1899,8 +1764,7 @@
       class: File
       size: 0
   tool: tests/import_schema-def_packed.cwl
-  label: packed_import_schema
-  id: 136
+  id: packed_import_schema
   doc: SchemaDefRequirement with $import, and packed
   tags: [ schema_def, workflow ]
 
@@ -1914,8 +1778,7 @@
     }
   }
   tool: tests/dir4.cwl
-  id: 137
-  label: job_input_secondary_subdirs
+  id: job_input_secondary_subdirs
   doc: Test specifying secondaryFiles in subdirectories of the job input document.
   tags: [ shell_command, command_line_tool ]
 
@@ -1929,8 +1792,7 @@
     }
   }
   tool: tests/dir4.cwl
-  id: 138
-  label: job_input_subdir_primary_and_secondary_subdirs
+  id: job_input_subdir_primary_and_secondary_subdirs
   doc: Test specifying secondaryFiles in same subdirectory of the job input as the primary input file.
   tags: [ shell_command, command_line_tool ]
 
@@ -1938,8 +1800,7 @@
   output:
     count_output: [16, 1]
   tool: tests/count-lines18-wf.cwl
-  id: 139
-  label: scatter_embedded_subworkflow
+  id: scatter_embedded_subworkflow
   doc: Test simple scatter over an embedded subworkflow
   tags: [ workflow, inline_javascript ]
 
@@ -1947,32 +1808,28 @@
   output:
     count_output: [16, 1]
   tool: tests/count-lines14-wf.cwl
-  id: 140
-  label: scatter_multi_input_embedded_subworkflow
+  id: scatter_multi_input_embedded_subworkflow
   doc: Test simple multiple input scatter over an embedded subworkflow
   tags: [ workflow, scatter, subworkflow, multiple_input, inline_javascript ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines15-wf.cwl
-  id: 141
   doc: Test twice nested subworkflow
-  label: workflow_embedded_subworkflow_embedded_subsubworkflow
+  id: workflow_embedded_subworkflow_embedded_subsubworkflow
   tags: [ workflow, subworkflow, inline_javascript ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines16-wf.cwl
-  id: 142
-  label: workflow_embedded_subworkflow_with_tool_and_subsubworkflow
+  id: workflow_embedded_subworkflow_with_tool_and_subsubworkflow
   doc: Test subworkflow of mixed depth with tool first
   tags: [ workflow, subworkflow, inline_javascript ]
 
 - job: tests/wc-job.json
   output: {count_output: 16}
   tool: tests/count-lines17-wf.cwl
-  id: 143
-  label: workflow_embedded_subworkflow_with_subsubworkflow_and_tool
+  id: workflow_embedded_subworkflow_with_subsubworkflow_and_tool
   doc: Test subworkflow of mixed depth with tool after
   tags: [ workflow, subworkflow, inline_javascript ]
 
@@ -1993,56 +1850,49 @@
         }
     }
   tool: tests/record-output-wf.cwl
-  id: 144
-  label: workflow_records_inputs_and_outputs
+  id: workflow_records_inputs_and_outputs
   doc: Test record type inputs to and outputs from workflows.
   tags: [ workflow, shell_command ]
 
 - job: tests/io-int.json
   output: {"o": 10}
   tool: tests/io-int-wf.cwl
-  id: 145
-  label: workflow_integer_input
+  id: workflow_integer_input
   doc: Test integer workflow input and outputs
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/io-int.json
   output: {"o": 10}
   tool: tests/io-int-optional-wf.cwl
-  id: 146
-  label: workflow_integer_input_optional_specified
+  id: workflow_integer_input_optional_specified
   doc: Test optional integer workflow inputs (specified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/empty.json
   output: {"o": 4}
   tool: tests/io-int-optional-wf.cwl
-  id: 147
-  label: workflow_integer_input_optional_unspecified
+  id: workflow_integer_input_optional_unspecified
   doc: Test optional integer workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/io-int.json
   output: {"o": 10}
   tool: tests/io-int-default-wf.cwl
-  id: 148
-  label: workflow_integer_input_default_specified
+  id: workflow_integer_input_default_specified
   doc: Test default integer workflow inputs (specified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/empty.json
   output: {"o": 8}
   tool: tests/io-int-default-wf.cwl
-  id: 149
-  label: workflow_integer_input_default_unspecified
+  id: workflow_integer_input_default_unspecified
   doc: Test default integer workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/empty.json
   output: {"o": 13}
   tool: tests/io-int-default-tool-and-wf.cwl
-  id: 150
-  label: workflow_integer_input_default_and_tool_integer_input_default
+  id: workflow_integer_input_default_and_tool_integer_input_default
   doc: Test default integer tool and workflow inputs (unspecified)
   tags: [ workflow, inline_javascript, expression_tool ]
 
@@ -2055,8 +1905,7 @@
             "checksum": "sha1$327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"
   }}
   tool: tests/io-file-default-wf.cwl
-  id: 151
-  label: workflow_file_input_default_unspecified
+  id: workflow_file_input_default_unspecified
   doc: Test File input with default unspecified to workflow
   tags: [ workflow ]
 
@@ -2069,8 +1918,7 @@
                 "size": 13
   }}
   tool: tests/io-file-default-wf.cwl
-  id: 152
-  label: workflow_file_input_default_specified
+  id: workflow_file_input_default_specified
   doc: Test File input with default specified to workflow
   tags: [ workflow ]
 
@@ -2084,8 +1932,7 @@
         "size": 0
   }}
   tool: tests/io-file-or-files.cwl
-  id: 153
-  label: clt_optional_union_input_file_or_files_with_array_of_one_file_provided
+  id: clt_optional_union_input_file_or_files_with_array_of_one_file_provided
   doc: Test input union type or File or File array to a tool with one file in array specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2099,8 +1946,7 @@
         "size": 1114
   }}
   tool: tests/io-file-or-files.cwl
-  id: 154
-  label: clt_optional_union_input_file_or_files_with_many_files_provided
+  id: clt_optional_union_input_file_or_files_with_many_files_provided
   doc: Test input union type or File or File array to a tool with a few files in array specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2114,8 +1960,7 @@
         "size": 1111
   }}
   tool: tests/io-file-or-files.cwl
-  id: 155
-  label: clt_optional_union_input_file_or_files_with_single_file_provided
+  id: clt_optional_union_input_file_or_files_with_single_file_provided
   doc: Test input union type or File or File array to a tool with one file specified.
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2129,136 +1974,119 @@
         "size": 10
   }}
   tool: tests/io-file-or-files.cwl
-  id: 156
-  label: clt_optional_union_input_file_or_files_with_nothing_provided
+  id: clt_optional_union_input_file_or_files_with_nothing_provided
   doc: Test input union type or File or File array to a tool with null specified.
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-int.json
   output: {"t1": 7}
   tool: tests/io-any-1.cwl
-  id: 157
-  label: clt_any_input_with_integer_provided
+  id: clt_any_input_with_integer_provided
   doc: Test Any parameter with integer input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-string.json
   output: {"t1": "7"}
   tool: tests/io-any-1.cwl
-  id: 158
-  label: clt_any_input_with_string_provided
+  id: clt_any_input_with_string_provided
   doc: Test Any parameter with string input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-file.json
   output: {"t1": "File"}
   tool: tests/io-any-1.cwl
-  id: 159
-  label: clt_any_input_with_file_provided
+  id: clt_any_input_with_file_provided
   doc: Test Any parameter with file input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-array.json
   output: {"t1": [1, "moocow"]}
   tool: tests/io-any-1.cwl
-  id: 160
-  label: clt_any_input_with_mixed_array_provided
+  id: clt_any_input_with_mixed_array_provided
   doc: Test Any parameter with array input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-record.json
   output: {"t1": {"moo": 1, "cow": 5}}
   tool: tests/io-any-1.cwl
-  id: 161
-  label: clt_any_input_with_record_provided
+  id: clt_any_input_with_record_provided
   doc: Test Any parameter with record input to a tool
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/io-any-int.json
   output: {"t1": 7}
   tool: tests/io-any-wf-1.cwl
-  id: 162
-  label: workflow_any_input_with_integer_provided
+  id: workflow_any_input_with_integer_provided
   doc: Test Any parameter with integer input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: tests/io-any-string.json
   output: {"t1": "7"}
   tool: tests/io-any-wf-1.cwl
-  id: 163
-  label: workflow_any_input_with_string_provided
+  id: workflow_any_input_with_string_provided
   doc: Test Any parameter with string input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: tests/io-any-file.json
   output: {"t1": "File"}
   tool: tests/io-any-wf-1.cwl
-  id: 164
-  label: workflow_any_input_with_file_provided
+  id: workflow_any_input_with_file_provided
   doc: Test Any parameter with file input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: tests/io-any-array.json
   output: {"t1": [1, "moocow"]}
   tool: tests/io-any-wf-1.cwl
-  id: 165
-  label: workflow_any_input_with_mixed_array_provided
+  id: workflow_any_input_with_mixed_array_provided
   doc: Test Any parameter with array input to a workflow
   tags: [ workflow, inline_javascript ]
 
 - job: tests/io-any-record.json
   output: {"t1": {"moo": 1, "cow": 5}}
   tool: tests/io-any-wf-1.cwl
-  id: 166
-  label: workflow_any_input_with_record_provided
+  id: workflow_any_input_with_record_provided
   doc: Test Any parameter with record input to a tool
   tags: [ workflow, inline_javascript ]
 
 - job: tests/empty.json
   output: {"o": "the default value"}
   tool: tests/io-union-input-default-wf.cwl
-  id: 167
-  label: workflow_union_default_input_unspecified
+  id: workflow_union_default_input_unspecified
   doc: Test union type input to workflow with default unspecified
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/io-any-file.json
   output: {"o": "File"}
   tool: tests/io-union-input-default-wf.cwl
-  id: 168
-  label: workflow_union_default_input_with_file_provided
+  id: workflow_union_default_input_with_file_provided
   doc: Test union type input to workflow with default specified as file
   tags: [ workflow, inline_javascript, expression_tool ]
 
 - job: tests/empty.json
   output: {"val": "moocow\n"}
   tool: tests/step-valuefrom4-wf.cwl
-  id: 169
-  label: workflowstep_valuefrom_string
+  id: workflowstep_valuefrom_string
   doc: Test valueFrom on workflow step from literal (string).
   tags: [ workflow, step_input ]
 
 - job: tests/wc-job.json
   output: {"val1": "whale.txt\n", "val2": "step1_out\n"}
   tool: tests/step-valuefrom5-wf.cwl
-  id: 170
-  label: workflowstep_valuefrom_file_basename
+  id: workflowstep_valuefrom_file_basename
   doc: Test valueFrom on workflow step using basename.
   tags: [ workflow, step_input ]
 
 - job: tests/output-arrays-int-job.json
   output: {"o": [0, 1, 2]}
   tool: tests/output-arrays-int.cwl
-  id: 171
-  label: expression_tool_int_array_output
+  id: expression_tool_int_array_output
   doc: Test output arrays in a tool (with ints).
   tags: [ expression_tool, inline_javascript ]
 
 - job: tests/output-arrays-int-job.json
   output: {"o": 12}
   tool: tests/output-arrays-int-wf.cwl
-  id: 172
-  label: workflowstep_int_array_input_output
+  id: workflowstep_int_array_input_output
   doc: Test output arrays in a workflow (with ints).
   tags: [ workflow, expression_tool, inline_javascript ]
 
@@ -2280,8 +2108,7 @@
     }
   ]}
   tool: tests/output-arrays-file-wf.cwl
-  id: 173
-  label: workflow_file_array_output
+  id: workflow_file_array_output
   doc: Test output arrays in a workflow (with Files).
   tags: [ workflow, expression_tool, inline_javascript ]
 
@@ -2295,8 +2122,7 @@
         "location": Any
   }}
   tool: "tests/docker-run-cmd.cwl"
-  id: 174
-  label: docker_entrypoint
+  id: docker_entrypoint
   doc: Test Docker ENTRYPOINT usage
   tags: [ command_line_tool, docker ]
 
@@ -2310,8 +2136,7 @@
         "size": 11
   }}
   tool: "tests/size-expression-tool.cwl"
-  id: 175
-  label: clt_file_size_property_with_empty_file
+  id: clt_file_size_property_with_empty_file
   doc: Test use of size in expressions for an empty file
   tags: [ command_line_tool, inline_javascript ]
 
@@ -2325,24 +2150,21 @@
         "size": 31
   }}
   tool: "tests/size-expression-tool.cwl"
-  id: 176
-  label: clt_file_size_property_with_multi_file
+  id: clt_file_size_property_with_multi_file
   doc: Test use of size in expressions for a few files
   tags: [ command_line_tool, inline_javascript ]
 
 - job: tests/null-expression-echo-job.json
   tool: tests/echo-tool.cwl
   should_fail: true
-  id: 177
-  label: any_without_defaults_unspecified_fails
+  id: any_without_defaults_unspecified_fails
   doc: Test Any without defaults, unspecified, should fail.
   tags: [ command_line_tool, required ]
 
 - job: tests/null-expression1-job.json
   tool: tests/echo-tool.cwl
   should_fail: true
-  id: 178
-  label: any_without_defaults_specified_fails
+  id: any_without_defaults_specified_fails
   doc: Test Any without defaults, specified, should fail.
   tags: [ command_line_tool, required ]
 
@@ -2353,8 +2175,7 @@
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
   tool: tests/count-lines9-wf-noET.cwl
-  id: 179
-  label: step_input_default_value_noexp
+  id: step_input_default_value_noexp
   doc: Test default value on step input parameter, no ExpressionTool
   tags: [ workflow, required ]
 
@@ -2365,8 +2186,7 @@
         checksum: sha1$e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e
         size: 2
   tool: tests/count-lines11-wf-noET.cwl
-  id: 180
-  label: step_input_default_value_overriden_noexp
+  id: step_input_default_value_overriden_noexp
   doc: Test default value on step input parameter overridden by provided source, no ExpressionTool
   tags: [ workflow, required ]
 
@@ -2376,8 +2196,7 @@
         class: File
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
-  id: 181
-  label: nested_workflow_noexp
+  id: nested_workflow_noexp
   tool: tests/count-lines8-wf-noET.cwl
   doc: Test nested workflow, without ExpressionTool
   tags: [ workflow, subworkflow ]
@@ -2388,8 +2207,7 @@
         class: File
         checksum: sha1$ad552e6dc057d1d825bf49df79d6b98eba846ebe
         size: 3
-  id: 182
-  label: wf_multiplesources_multipletypes_noexp
+  id: wf_multiplesources_multipletypes_noexp
   tool: tests/sum-wf-noET.cwl
   doc: Test step input with multiple sources with multiple types, without ExpressionTool
   tags: [ workflow, step_input, inline_javascript, multiple_input ]
@@ -2402,8 +2220,7 @@
         size: 2
         class: File
         checksum: sha1$7448d8798a4380162d4b56f9b452e2f6f9e24e7a
-  id: 183
-  label: dynamic_resreq_wf_optional_file_default
+  id: dynamic_resreq_wf_optional_file_default
   doc: >-
     Within a workflow, test accessing the size attribute of an optional input
     File as part of a CommandLineTool's ResourceRequirement calculation. The
@@ -2419,8 +2236,7 @@
         size: 2
         class: File
         checksum: sha1$7448d8798a4380162d4b56f9b452e2f6f9e24e7a
-  id: 184
-  label: dynamic_resreq_wf_optional_file_step_default
+  id: dynamic_resreq_wf_optional_file_step_default
   doc: >-
     Within a workflow, test accessing the size attribute of an optional input
     File as part of a CommandLineTool's ResourceRequirement calculation. The
@@ -2430,8 +2246,7 @@
 
 - tool: tests/dynresreq-workflow-inputdefault.cwl
   job: tests/empty.json
-  id: 185
-  label: dynamic_resreq_wf_optional_file_wf_default
+  id: dynamic_resreq_wf_optional_file_wf_default
   output:
     cores:
         location: output
@@ -2446,8 +2261,7 @@
 
 - job: tests/cat-job.json
   output: {count_output: 1}
-  id: 186
-  label: step_input_default_value_overriden_2nd_step
+  id: step_input_default_value_overriden_2nd_step
   tool: tests/count-lines11-extra-step-wf.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2460,8 +2274,7 @@
         class: File
         checksum: sha1$e5fa44f2b31c1fb553b6021e7360d07d5d91ff5e
         size: 2
-  id: 187
-  label: step_input_default_value_overriden_2nd_step_noexp
+  id: step_input_default_value_overriden_2nd_step_noexp
   tool: tests/count-lines11-extra-step-wf-noET.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2470,8 +2283,7 @@
 
 - job: tests/empty.json
   output: {count_output: 16}
-  id: 188
-  label: step_input_default_value_overriden_2nd_step_null
+  id: step_input_default_value_overriden_2nd_step_null
   tool: tests/count-lines11-null-step-wf.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2484,8 +2296,7 @@
         class: File
         checksum: sha1$3596ea087bfdaf52380eae441077572ed289d657
         size: 3
-  id: 189
-  label: step_input_default_value_overriden_2nd_step_null_noexp
+  id: step_input_default_value_overriden_2nd_step_null_noexp
   tool: tests/count-lines11-null-step-wf-noET.cwl
   doc: >-
     Test default value on step input parameter overridden by provided source.
@@ -2499,8 +2310,7 @@
       checksum: sha1$47a013e660d408619d894b20806b1d5086aab03b
       class: File
       size: 13
-  id: 190
-  label: stdin_from_directory_literal_with_local_file
+  id: stdin_from_directory_literal_with_local_file
   doc: Pipe to stdin from user provided local File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2511,8 +2321,7 @@
       checksum: sha1$ef88e689559565999700d6fea7cf7ba306d04360
       class: File
       size: 26
-  id: 191
-  label: stdin_from_directory_literal_with_literal_file
+  id: stdin_from_directory_literal_with_literal_file
   doc: Pipe to stdin from literal File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2523,8 +2332,7 @@
       checksum: sha1$ef88e689559565999700d6fea7cf7ba306d04360
       class: File
       size: 26
-  id: 192
-  label: directory_literal_with_literal_file_nostdin
+  id: directory_literal_with_literal_file_nostdin
   doc: Test non-stdin reference to literal File via a Directory literal
   tags: [ command_line_tool, required ]
 
@@ -2535,16 +2343,14 @@
       location: output
       class: File
       size: 4
-  id: 193
-  label: no_inputs_commandlinetool
+  id: no_inputs_commandlinetool
   doc: Test CommandLineTool without inputs
   tags: [ command_line_tool, required ]
 
 - tool: tests/no-outputs-tool.cwl
   job: tests/cat-job.json
   output: {}
-  id: 194
-  label: no_outputs_commandlinetool
+  id: no_outputs_commandlinetool
   doc: Test CommandLineTool without outputs
   tags: [ command_line_tool, required ]
 
@@ -2555,16 +2361,14 @@
       location: output
       class: File
       size: 4
-  id: 195
-  label: no_inputs_workflow
+  id: no_inputs_workflow
   doc: Test Workflow without inputs
   tags: [ workflow, required ]
 
 - tool: tests/no-outputs-wf.cwl
   job: tests/cat-job.json
   output: {}
-  id: 196
-  label: no_outputs_workflow
+  id: no_outputs_workflow
   doc: Test Workflow without outputs
   tags: [ workflow, required ]
 
@@ -2575,8 +2379,7 @@
       class: File
       checksum: "sha1$2132943d72c39423e0b9425cbc40dfd5bf3e9cb2"
       size: 39
-  id: 197
-  label: anonymous_enum_in_array
+  id: anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record
   tags: [command_line_tool, required]
 
@@ -2587,8 +2390,7 @@
       class: File
       checksum: "sha1$f17c7d81f66e1520fca25b96b90eeeae5bbf08b0"
       size: 39
-  id: 198
-  label: schema-def_anonymous_enum_in_array
+  id: schema-def_anonymous_enum_in_array
   doc: Test an anonymous enum inside an array inside a record, SchemaDefRequirement
   tags: [command_line_tool, schema_def]
 
@@ -2600,26 +2402,23 @@
       location: output
       size: 24
   tool: tests/wc-tool-shortcut.cwl
-  label: stdin_shorcut
+  id: stdin_shorcut
   doc: Test command execution in with stdin and stdout redirection using stdin shortcut
   tags: [ command_line_tool, docker ]
-  id: 199
 
 - job: tests/record-secondaryFiles-job.yml
   output: {}
   tool: tests/record-in-secondaryFiles.cwl
-  label: secondary_files_in_unnamed_records
+  id: secondary_files_in_unnamed_records
   doc: Test secondaryFiles on anonymous record fields
   tags: [ command_line_tool, required ]
-  id: 200
 
 - job: tests/record-secondaryFiles-job.yml
   output: {}
   tool: tests/record-sd-secondaryFiles.cwl
-  label: secondary_files_in_named_records
+  id: secondary_files_in_named_records
   doc: Test secondaryFiles on SchemaDefRequirement record fields
   tags: [ command_line_tool, schema_def ]
-  id: 201
 
 - job: tests/empty.json
   output: {
@@ -2671,58 +2470,51 @@
     }
   }
   tool: tests/record-out-secondaryFiles.cwl
-  label: secondary_files_in_output_records
+  id: secondary_files_in_output_records
   doc: Test secondaryFiles on output record fields
   tags: [ command_line_tool, required ]
-  id: 202
 
 - job: tests/record-secondaryFiles-job.yml
   output: {}
   tool: tests/record-in-secondaryFiles-wf.cwl
-  label: secondary_files_workflow_propagation
+  id: secondary_files_workflow_propagation
   doc: Test secondaryFiles propagation through workflow
   tags: [ workflow, required ]
-  id: 203
 
 - job: tests/record-secondaryFiles-job.yml
   should_fail: true
   tool: tests/record-in-secondaryFiles-missing-wf.cwl
-  label: secondary_files_missing
+  id: secondary_files_missing
   doc: Test checking when secondaryFiles are missing
   tags: [ workflow, required ]
-  id: 204
 
 - job: tests/record-format-job.yml
   output: {}
   tool: tests/record-in-format.cwl
-  label: input_records_file_entry_with_format
+  id: input_records_file_entry_with_format
   doc: Test format on anonymous record fields
   tags: [ command_line_tool, required ]
-  id: 205
 
 - job: tests/record-format-job2.yml
   should_fail: true
   tool: tests/record-in-format.cwl
-  label: input_records_file_entry_with_format_and_bad_regular_input_file_format
+  id: input_records_file_entry_with_format_and_bad_regular_input_file_format
   doc: Test file format checking on parameter
   tags: [ command_line_tool, format_checking ]
-  id: 206
 
 - job: tests/record-format-job3.yml
   should_fail: true
   tool: tests/record-in-format.cwl
   doc: Test file format checking on record field
-  label: input_records_file_entry_with_format_and_bad_entry_file_format
+  id: input_records_file_entry_with_format_and_bad_entry_file_format
   tags: [ command_line_tool, format_checking ]
-  id: 207
 
 - job: tests/record-format-job4.yml
   should_fail: true
   tool: tests/record-in-format.cwl
   doc: Test file format checking on array item
-  label: input_records_file_entry_with_format_and_bad_entry_array_file_format
+  id: input_records_file_entry_with_format_and_bad_entry_array_file_format
   tags: [ command_line_tool, format_checking ]
-  id: 208
 
 - job: tests/record-secondaryFiles-job.yml
   output: {
@@ -2744,20 +2536,18 @@
     }
   }
   tool: tests/record-out-format.cwl
-  label: record_output_file_entry_format
+  id: record_output_file_entry_format
   doc: Test format on output record fields
   tags: [ command_line_tool, format_checking ]
-  id: 209
 
 - job: tests/wf-loadContents-job.yml
   output: {
     "my_int": 42
   }
   tool: tests/wf-loadContents.cwl
-  label: workflow_input_inputBinding_loadContents
+  id: workflow_input_inputBinding_loadContents
   doc: Test WorkflowInputParameter.inputBinding.loadContents
   tags: [ workflow, step_input, inline_javascript, expression_tool ]
-  id: 210
 
 - job: tests/wf-loadContents-job.yml
   output: {
@@ -2765,125 +2555,111 @@
   }
   tool: tests/wf-loadContents2.cwl
   doc: Test WorkflowInputParameter.loadContents
-  label: workflow_input_loadContents_without_inputBinding
+  id: workflow_input_loadContents_without_inputBinding
   tags: [ workflow, step_input, inline_javascript, expression_tool ]
-  id: 211
 
 - job: tests/wf-loadContents-job.yml
   output: {
     "my_int": 42
   }
   tool: tests/wf-loadContents3.cwl
-  label: expression_tool_input_loadContents
+  id: expression_tool_input_loadContents
   doc: Test loadContents on InputParameter.loadContents (expression)
   tags: [ workflow, step_input, inline_javascript, expression_tool ]
-  id: 212
 
 - job: tests/wf-loadContents-job.yml
   output: {
     "my_int": 42
   }
   tool: tests/wf-loadContents4.cwl
-  label: workflow_step_in_loadContents
+  id: workflow_step_in_loadContents
   doc: Test WorkflowStepInput.loadContents
   tags: [ workflow, step_input, inline_javascript, expression_tool ]
-  id: 213
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/timelimit.cwl
-  label: timelimit_basic
+  id: timelimit_basic
   doc: Test that job fails when exceeding time limit
   tags: [ command_line_tool, timelimit ]
-  id: 214
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/timelimit2.cwl
-  label: timelimit_invalid
+  id: timelimit_invalid
   doc: Test invalid time limit value
   tags: [ command_line_tool, timelimit ]
-  id: 215
 
 - job: tests/empty.json
   output: {}
   tool: tests/timelimit3.cwl
-  label: timelimit_zero_unlimited
+  id: timelimit_zero_unlimited
   doc: Test zero timelimit means no limit
   tags: [ command_line_tool, timelimit ]
-  id: 216
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/timelimit4.cwl
-  label: timelimit_from_expression
+  id: timelimit_from_expression
   doc: Test expression in time limit
   tags: [ command_line_tool, timelimit, inline_javascript ]
-  id: 217
 
 - job: tests/empty.json
   output:
     status: Done
   tool: tests/timelimit5.cwl
-  label: timelimit_expressiontool
+  id: timelimit_expressiontool
   doc: Test timelimit in expressiontool is ignored
   tags: [ expression_tool, timelimit, inline_javascript ]
-  id: 218
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/timelimit-wf.cwl
-  label: timelimit_basic_wf
+  id: timelimit_basic_wf
   doc: Test that tool in workflow fails when exceeding time limit
   tags: [ workflow, timelimit ]
-  id: 219
 
 - job: tests/empty.json
   output:
     o: time passed
   tool: tests/timelimit2-wf.cwl
-  label: timelimit_invalid_wf
+  id: timelimit_invalid_wf
   doc: Test that workflow level time limit is not applied to workflow execution time
   tags: [ workflow, timelimit, inline_javascript ]
-  id: 220
 
 - job: tests/empty.json
   output:
     o: time passed
   tool: tests/timelimit3-wf.cwl
-  label: timelimit_zero_unlimited_wf
+  id: timelimit_zero_unlimited_wf
   doc: Test zero timelimit means no limit in workflow
   tags: [ workflow, timelimit, inline_javascript ]
-  id: 221
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/timelimit4-wf.cwl
-  label: timelimit_from_expression_wf
+  id: timelimit_from_expression_wf
   doc: Test expression in time limit in workflow
   tags: [ workflow, timelimit, inline_javascript ]
-  id: 222
 
 - job: tests/empty.json
   output: {}
   tool: tests/networkaccess.cwl
   doc: Test networkaccess enabled
-  label: networkaccess
+  id: networkaccess
   tags: [ command_line_tool, networkaccess ]
-  id: 223
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/networkaccess2.cwl
-  label: networkaccess_disabled
+  id: networkaccess_disabled
   doc: Test networkaccess is disabled by default
   tags: [ networkaccess, command_line_tool ]
-  id: 224
 
 - job: tests/stage-array-job.json
   tool: tests/stage-array.cwl
   doc: Test null and array input in InitialWorkDirRequirement
-  label: stage_null_array
+  id: stage_null_array
   output:
       "output": {
         "basename": "lsout",
@@ -2893,12 +2669,11 @@
         "size": 32
       }
   tags: [ resource, command_line_tool ]
-  id: 225
 
 - job: tests/stage-array-dirs-job.yml
   tool: tests/stage-array-dirs.cwl
   doc: Test array of directories InitialWorkDirRequirement
-  label: stage_array_dirs
+  id: stage_array_dirs
   output: {
     "output": [
             {
@@ -2916,7 +2691,6 @@
         ]
     }
   tags: [ resource, command_line_tool ]
-  id: 226
 
 - job: tests/env-job3.yaml
   output:
@@ -2926,10 +2700,9 @@
       location: out
       size: 15
   tool: tests/env-tool3.cwl
-  label: cwl_requirements_addition
+  id: cwl_requirements_addition
   doc: Test requirements in input document via EnvVarRequirement
   tags: [ command_line_tool, input_object_requirements ]
-  id: 227
 
 - job: tests/env-job3.yaml
   output:
@@ -2939,10 +2712,9 @@
       location: out
       size: 15
   tool: tests/env-tool4.cwl
-  label: cwl_requirements_override_expression
+  id: cwl_requirements_override_expression
   doc: Test conflicting requirements in input document via EnvVarRequirement and expression
   tags: [ command_line_tool, input_object_requirements ]
-  id: 228
 
 - job: tests/env-job4.yaml
   output:
@@ -2951,11 +2723,10 @@
       checksum: sha1$715e62184492851512a020c36ab7118eca114a59
       location: out
       size: 23
-  label: cwl_requirements_override_static
+  id: cwl_requirements_override_static
   tool: tests/env-tool3.cwl
   doc: Test conflicting requirements in input document via EnvVarRequirement
   tags: [ command_line_tool, input_object_requirements ]
-  id: 229
 
 - job: tests/initialworkdirrequirement-docker-out-job.json
   output:
@@ -2972,9 +2743,8 @@
       "size": 12010
   tool: tests/initialworkdir-glob-fullpath.cwl
   doc: Test output of InitialWorkDir
-  label: initial_work_dir_output
+  id: initial_work_dir_output
   tags: [ initial_work_dir, command_line_tool ]
-  id: 230
 
 - job: tests/initialworkdirrequirement-docker-out-job.json
   output:
@@ -2991,22 +2761,20 @@
       "size": 12010
   tool: tests/initialworkdir-glob-fullpath.cwl
   doc: Test if full paths are allowed in glob
-  label: glob_full_path
+  id: glob_full_path
   tags: [ initial_work_dir, command_line_tool ]
-  id: 231
 
 - job: tests/empty.json
   should_fail: true
   tool: tests/glob-path-error.cwl
   doc: Test fail trying to glob outside output directory
-  label: fail_glob_outside_output_dir
+  id: fail_glob_outside_output_dir
   tags: [ command_line_tool, docker ]
-  id: 232
 
 - job: tests/empty.json
   tool: tests/symlink-illegal.cwl
   doc: symlink to file outside of working directory should NOT be retrieved
-  label: symlink_to_file_out_of_workdir_illegal
+  id: symlink_to_file_out_of_workdir_illegal
   output:
     output_file:
       "class": "File"
@@ -3015,35 +2783,32 @@
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
   should_fail: true
   tags: [ command_line_tool ]
-  id: 233
 
 - job: tests/empty.json
   tool: tests/symlink-legal.cwl
   doc: symlink to file inside of working directory should be retrieved
-  label: symlink-to-file-in-workdir-legal
+  id: symlink-to-file-in-workdir-legal
   output:
     output_file:
       "class": "File"
       "size": 27
       "basename": "symlink.txt"
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
-  id: 234
   tags: [ command_line_tool ]
 
 - job: tests/empty.json
   tool: tests/inp_update_wf.cwl
   doc: inplace update has side effect on file content
-  label: inplace_update_on_file_content
+  id: inplace_update_on_file_content
   tags: [ inplace_update, workflow ]
   output:
     a: 4
     b: 4
-  id: 235
 
 - job: tests/empty.json
   tool: tests/inpdir_update_wf.cwl
   doc: inplace update has side effect on directory content
-  label: inplace_update_on_dir_content
+  id: inplace_update_on_dir_content
   tags: [ inplace_update, workflow ]
   output: {
     a: [
@@ -3061,11 +2826,10 @@
             }
         ]
 }
-  id: 236
 
 - doc: Test that OutputBinding.glob accepts Directories
   job: tests/empty.json
-  label: outputbinding_glob_directory
+  id: outputbinding_glob_directory
   tool: tests/glob_directory.cwl
   output:
     directories:
@@ -3079,10 +2843,9 @@
           class: "Directory"
           listing: []
   tags: [ required, command_line_tool ]
-  id: 237
 
 - doc: Test that array of input files can be staged to directory with entryname
-  label: stage_file_array_to_dir
+  id: stage_file_array_to_dir
   tool: tests/stage_file_array.cwl
   job: tests/stage_file_array.job.json
   output:
@@ -3114,10 +2877,9 @@
         }
       ]
   tags: [ command_line_tool, initial_work_dir, inline_javascript ]
-  id: 238
 
 - doc: Test that array of input files can be staged to directory with basename
-  label: stage_file_array_to_dir_basename
+  id: stage_file_array_to_dir_basename
   tool: tests/stage_file_array_basename.cwl
   job: tests/stage_file_array.job.json
   output:
@@ -3149,10 +2911,9 @@
         }
       ]
   tags: [ command_line_tool, initial_work_dir, inline_javascript ]
-  id: 239
 
 - doc: Test that if array of input files are staged to directory with basename and entryname, entryname overrides
-  label: stage_file_array_to_dir_basename_entryname
+  id: stage_file_array_to_dir_basename_entryname
   tool: tests/stage_file_array_basename_and_entryname.cwl
   job: tests/stage_file_array.job.json
   output:
@@ -3184,7 +2945,6 @@
         }
       ]
   tags: [ command_line_tool, initial_work_dir, inline_javascript ]
-  id: 240
 
 - job: tests/empty.json
   output:
@@ -3193,41 +2953,37 @@
       basename: foo
       checksum: sha1$fa98d6085770a79e44853d575cd3ab40c0f1f4de
   tool: tests/runtime-paths-distinct.cwl
-  label: tmpdir_is_not_outdir
+  id: tmpdir_is_not_outdir
   doc: Test that runtime.tmpdir is not runtime.outdir
   tags: [ command_line_tool ]
-  id: 241
 
 - job: tests/listing-job.yml
   tool: tests/listing_none1.cwl
-  label: listing_default_none
+  id: listing_default_none
   output:
     out: true
   doc: Test that default behavior is 'no_listing' if not specified
   tags: [ command_line_tool ]
-  id: 242
 
 - job: tests/listing-job.yml
   tool: tests/listing_none2.cwl
-  label: listing_requirement_none
+  id: listing_requirement_none
   output:
     out: true
   doc: Test that 'listing' is not present when LoadListingRequirement is 'no_listing'
   tags: [ command_line_tool ]
-  id: 243
 
 - job: tests/listing-job.yml
   tool: tests/listing_none3.cwl
-  label: listing_loadListing_none
+  id: listing_loadListing_none
   output:
     out: true
   doc: Test that 'listing' is not present when loadListing on input parameter is 'no_listing'
   tags: [ command_line_tool ]
-  id: 244
 
 - job: tests/listing-job.yml
   tool: tests/listing_shallow1.cwl
-  label: listing_requirement_shallow
+  id: listing_requirement_shallow
   output:
     out: true
   doc: >
@@ -3235,11 +2991,10 @@
     subdirectory object when LoadListingRequirement is
     'shallow_listing'
   tags: [ command_line_tool ]
-  id: 245
 
 - job: tests/listing-job.yml
   tool: tests/listing_shallow2.cwl
-  label: listing_loadListing_shallow
+  id: listing_loadListing_shallow
   output:
     out: true
   doc: >
@@ -3247,11 +3002,10 @@
     subdirectory object when loadListing on input parameter loadListing is
     'shallow_listing'
   tags: [ command_line_tool ]
-  id: 246
 
 - job: tests/listing-job.yml
   tool: tests/listing_deep1.cwl
-  label: listing_requirement_deep
+  id: listing_requirement_deep
   output:
     out: true
   doc: >
@@ -3259,11 +3013,10 @@
     subdirectory objects when LoadListingRequirement is
     'deep_listing'
   tags: [ command_line_tool ]
-  id: 247
 
 - job: tests/listing-job.yml
   tool: tests/listing_deep2.cwl
-  label: listing_loadListing_deep
+  id: listing_loadListing_deep
   output:
     out: true
   doc: >
@@ -3271,53 +3024,47 @@
     subdirectory objects when input parameter loadListing is
     'deep_listing'
   tags: [ command_line_tool ]
-  id: 248
 
 - job: tests/echo-position-expr-job.yml
   tool: tests/echo-position-expr.cwl
-  label: inputBinding_position_expr
+  id: inputBinding_position_expr
   output:
     out: "🕺 1 singular sensation!\n"
   doc: >
     Test for expression in the InputBinding.position field; also test using emoji in CWL document and tool output
   tags: [ command_line_tool, required ]
-  id: 249
 
 - job: tests/empty.json
   tool: tests/exitcode.cwl
-  label: outputEval_exitCode
+  id: outputEval_exitCode
   output:
     code: 7
   doc: Can access exit code in outputEval
   tags: [ command_line_tool, required ]
-  id: 250
 
 - tool: tests/echo-tool-packed.cwl
   job: tests/env-job.json
   output:
     {"out": "hello test env\n"}
-  label: any_input_param_graph_no_default
+  id: any_input_param_graph_no_default
   doc: Test use of $graph without specifying which process to run
   tags: [ required, command_line_tool ]
-  id: 251
 
 - tool: tests/echo-tool-packed2.cwl
   job: tests/env-job.json
   output:
     {"out": "hello test env\n"}
-  label: any_input_param_graph_no_default_hashmain
+  id: any_input_param_graph_no_default_hashmain
   doc: >
     Test use of $graph without specifying which process to run,
     hash-prefixed "main"
   tags: [ required, command_line_tool ]
-  id: 252
 
 - tool: tests/optional-numerical-output-0.cwl
   job: tests/empty.json
   output:
     {"out": 0}
-  label: optional_numerical_output_returns_0_not_null
+  id: optional_numerical_output_returns_0_not_null
   doc: |
     Test that optional number output is returned as 0, not null
   tags: [ inline_javascript, command_line_tool ]
-  id: 253


### PR DESCRIPTION
It moves string-based `label` fields to the `id` field for https://github.com/common-workflow-language/cwltest/issues/110.

Related: https://github.com/common-workflow-language/common-workflow-language/pull/954