### PR TITLE
Add support for markdown report

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -51,6 +51,7 @@ SELF=""
 BADGE=""
 TIMEOUT=""
 TAGS=""
+REPORT_URI="https://github.com/common-workflow-language/cwl-$CWL_VER/tree/main/"
 
 while [ -n "$1" ]
 do
@@ -95,7 +96,7 @@ do
             SELF=1
             ;;
         --badgedir=*)
-            BADGE=$arg
+            BADGE="$arg --baseuri=$REPORT_URI"
             ;;
         --timeout=*)
             TIMEOUT=$arg


### PR DESCRIPTION
This request is to support for markdown report feature that was implemented in https://github.com/common-workflow-language/cwltest/pull/209.

Here is an example of a markdown report.

---
# `command_line_tool` tests
## List of passed tests
- [filesarray_secondaryfiles2](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L1268) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/docker-array-secondaryfiles.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/docker-array-secondaryfiles-job2.json))
- [any_without_defaults_unspecified_fails](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L2156) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/echo-tool.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/null-expression-echo-job.json))
- [any_without_defaults_specified_fails](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L2163) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/echo-tool.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/null-expression1-job.json))
- [input_records_file_entry_with_format_and_bad_regular_input_file_format](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L2497) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-in-format.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-format-job2.yml))
- [input_records_file_entry_with_format_and_bad_entry_file_format](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L2504) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-in-format.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-format-job3.yml))
- [input_records_file_entry_with_format_and_bad_entry_array_file_format](https://github.com/common-workflow-language/cwl-v1.1/tree/main/conformance_tests.yaml#L2511) ([tool](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-in-format.cwl), [job](https://github.com/common-workflow-language/cwl-v1.1/tree/main/tests/record-format-job4.yml))
...
---